### PR TITLE
feat: 로그인 및 토큰 URL을 account 경로로 통일

### DIFF
--- a/budget_management_project/account/urls.py
+++ b/budget_management_project/account/urls.py
@@ -7,7 +7,7 @@ app_name = "account"
 
 urlpatterns = [
     path('account', RegisterView.as_view(), name='account'),
-    path('token', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('token/refresh', TokenRefreshView.as_view(), name='token_refresh'),
+    path('account/login', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('account/token/refresh', TokenRefreshView.as_view(), name='token_refresh'),
     
 ]


### PR DESCRIPTION
- JWT 로그인과 토큰 갱신 경로를  account로 통합
- 기존의 /token 을/account/login으로 변경
- 기존의 /token/refresh를 /account/token/refresh로 변경


## 📝작업 내용

> account urls.py에서 기존의 /token 을/account/login으로 변경하였습니다.
> account urls.py에서 /token/refresh를 /account/token/refresh로 변경하였습니다.

